### PR TITLE
Clear _mouseDownView when ending a touch/drag

### DIFF
--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -1760,6 +1760,9 @@ SC.RootResponder = SC.Object.extend(
         if (this._drag) {
           this._drag.tryToPerform('mouseUp', touch) ;
           this._drag = null ;
+          // [CC] _mouseDownView must also be cleared to properly end a drag
+          this._mouseDownView = null;
+          // [/CC]
         }
 
         // unassign


### PR DESCRIPTION
[[#171821072](https://www.pivotaltracker.com/story/show/171821072)] iPad: Collapse of child table causes drop zone to hide the expand icons

`SC.RootResponder.touchend()` was not properly clearing the drag state at the end of the touch. In particular, everywhere `this._drag` is cleared, `this._mouseDownView` should also be cleared. The one place this didn't occur was in the `touchend` handler, which is why the bug was touch-only.

@jsandoe I'll submit the corresponding CODAP PR once this PR is merged so as to avoid having to point the CODAP PR to this PR branch initially and then having to change it to point to the `dg-sc-1.11 branch after the merge.