### PR TITLE
`equals()` testing function uses strict equality for unit testing

### DIFF
--- a/frameworks/testing/system/plan.js
+++ b/frameworks/testing/system/plan.js
@@ -559,7 +559,7 @@ CoreTest.Plan = {
     */
     equals: function equals(actual, expected, msg) {
       if (msg === undefined) msg = null; // make sure ok logs properly
-      return this.ok(actual == expected, actual, expected, msg);
+      return this.ok(actual === expected, actual, expected, msg);
     },
 
     /**


### PR DESCRIPTION
`equals()` testing function uses strict equality (===) rather than lax equality (==) when performing unit tests

I was shocked to discover that our unit tests were using this lax equality test. It seems to me we should always adopt the strict equality test by default and can always back off to lax equality using `ok()` if necessary.