### PR TITLE
Fix SproutCore's array.prototype.find() override

### DIFF
--- a/frameworks/runtime/mixins/enumerable.js
+++ b/frameworks/runtime/mixins/enumerable.js
@@ -1138,7 +1138,8 @@ Array.prototype.isEnumerable = YES;
       var len = this.length;
       if (target === undefined) target = null;
 
-      var next, ret = null, found = NO;
+      // [CC] return undefined on failure (as per standard)
+      var next, ret = undefined, found = NO;
       for (var idx = 0; idx < len && !found; idx++) {
         next = this[idx];
         if (found = callback.call(target, next, idx, this)) ret = next;


### PR DESCRIPTION
After bringing [slate-editor 0.5.0](https://github.com/concord-consortium/slate-editor/releases/tag/v0.5.0) into CODAP recently for testing, editing an existing image crashed in CODAP but worked fine outside of CODAP. After spending the better part of a day debugging the issue, it eventually turned out that SproutCore overrides the native [Array.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) and changes the behavior in ways that are incompatible with Slate code. I had actually considered the possibility of a SproutCore override issue earlier in the day but had dismissed it because CODAP now has ES5/ES6 polyfills in place, so surely there would be no need for SproutCore to provide its own implementation. There is even a [helpful comment](https://github.com/concord-consortium/codap-sproutcore/blob/7d0b0a85f64fc560e425930ffe102418094b4d0b/frameworks/runtime/mixins/enumerable.js#L22-L24) in the SproutCore code that implies as much. That assumption proved incorrect, however, for in another comment deeper within the implementation, they explain that some functions are always overridden, even if they already exist, ["b/c we do it better."](https://github.com/concord-consortium/codap-sproutcore/blob/7d0b0a85f64fc560e425930ffe102418094b4d0b/frameworks/runtime/mixins/enumerable.js#L1070-L1072)

The primary reason for the override, it appears, is that the SproutCore version of the `find()` function takes a second argument, the `target`, after the `callback` function. SproutCore's `find()` function uses [Function.prototype.call](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call) to set `this` for the `callback` to the `target`, which allows SC object methods to be used as callback functions. In and of itself, adding an additional optional argument to the signature of the `find()` function is unobjectionable, as it doesn't change the behavior of clients that use the standard signature. The other more insidious change, however, which is not obviously intentional, is that it changes the return value when no matching value is found from `undefined` to `null`. In Slate code, an `undefined` return value from a plugin query indicates that the query was not handled and so Slate propagates the query to the next plugin, while a `null` return stops propagation. Some plugin queries return the result of `Array.prototype.find()` to indicate that propagation should continue if no matching value is found.

Therefore, the proposal here is to leave SproutCore's override of `Array.prototype.find()` in place to support the additional `target` argument, but to change the return value when no matching value is found from `null` to `undefined` to match the behavior of the native `Array.prototype.find()`. This has the immediate effect of allowing the `slate-editor` library to work as expected as well as the longer-term benefit of eliminating a lurking difficult-to-track-down bug whenever the _next_ library assumes that `Array.prototype.find()` behaves in the standard way. This is not without risk, however, as SproutCore (or even CODAP, although that seems less likely) may have code that explicitly assumes a `null` return on failure. I would argue that it is still worth making this change despite the risk, however, as such code should rightly be considered a bug itself and so rooting out any such code that might exist is worthwhile in the interest of eliminating the lurking potential for future bugs resulting from the non-standard behavior.

Because of these risks, however, this should only be merged when there is an expectation of widespread testing before the next release to maximize the chance that affected code might be found before release. Static analysis would also be beneficial, but would be a non-trivial exercise. VSCode reports 199 instances of `find(` in CODAP/SproutCore code (not including SC's tests). Many of these use `DG.store.find()` or `$.find()`, for instance, which are presumably unrelated, but reviewing this list to see if there are any that explicitly test for a `null` return from `Array.prototype.find()` would still be worthwhile. Finally, CODAP should not update to the 0.5.0 version of the `slate-editor` library until this issue is resolved.

If this is deemed to be too risky or too much work, an alternative approach would be to monkey-patch the slate code as it is built into the bundle. I'm aware of two places the code would need to be monkey-patched, but I can't guarantee that there aren't others, and any such approach would run the risk of encountering additional code in slate or other libraries that needed to be monkey-patched down the road. Unfortunately, there isn't a simple option here.